### PR TITLE
Pass in the line number and keep the input stream available (for finding out the read file)

### DIFF
--- a/readline.js
+++ b/readline.js
@@ -13,17 +13,19 @@ var readLine = module.exports = function(file, opts) {
   opts = opts || {};
   var self = this,
       line = [],
-      emit = function(line) {
-        self.emit('line', new Buffer(line).toString());
+      lineCount = 0,
+      emit = function(line, count) {
+        self.emit('line', new Buffer(line).toString(), count);
       };
-
-  fs.createReadStream(file).on('open', function(fd) {
-    self.emit('open', fd);
-  })
+    this.input = fs.createReadStream(file);
+    this.input.on('open', function(fd) {
+        self.emit('open', fd);
+    })
   .on('data', function(data) {
      for (var i = 0; i < data.length; i++) {
         if (0 <= newlines.indexOf(data[i])) { // Newline char was found.
-          if (line.length) emit(line);
+          lineCount++;
+          if (line.length) emit(line, lineCount);
           line = []; // Empty buffer.
         } else {
           line.push(data[i]); // Buffer new line data.
@@ -35,7 +37,7 @@ var readLine = module.exports = function(file, opts) {
   })
   .on('end', function() {
     // Emit last line if anything left over since EOF won't trigger it.
-    if (line.length) emit(line);
+    if (line.length) emit(line, lineCount);
     self.emit('end');
   })
   .on('close', function() {


### PR DESCRIPTION
I added 
- sending through of the line number as well
- keeping the input stream available in the object so that it's easy for listeners to read the path of the streamed file