### PR TITLE
Ensure the buffer is emptied on event handler errors and that the error is re-emitted

### DIFF
--- a/readline.js
+++ b/readline.js
@@ -14,7 +14,7 @@ var readLine = module.exports = function(file, opts) {
       emit = function(lineCount, byteCount) {
         self.emit('line', new Buffer(line).toString(), lineCount, byteCount);
       };
-    this.input = ('string' === typeof file)? fs.createReadStream(file, opts):file;
+    this.input = ('string' === typeof file) ? fs.createReadStream(file, opts) : file;
     this.input.on('open', function(fd) {
         self.emit('open', fd);
     })

--- a/readline.js
+++ b/readline.js
@@ -7,17 +7,19 @@ var readLine = module.exports = function(file, opts) {
 
   EventEmitter.call(this);
   opts = opts || {};
+  opts.maxLineLength = opts.maxLineLength || 4096; // 4K
   var self = this,
-      line = [],
+      lineBuffer = new Buffer(opts.maxLineLength),
+      lineLength = 0,
       lineCount = 0,
       byteCount = 0,
       emit = function(lineCount, byteCount) {
         try {
-          self.emit('line', new Buffer(line).toString(), lineCount, byteCount);
+          self.emit('line', lineBuffer.slice(0, lineLength).toString(), lineCount, byteCount);
         } catch (err) {
           self.emit('error', err);
         } finally {
-          line = []; // Empty buffer.
+          lineLength = 0; // Empty buffer.
         }
       };
     this.input = ('string' === typeof file) ? fs.createReadStream(file, opts) : file;
@@ -28,9 +30,10 @@ var readLine = module.exports = function(file, opts) {
      for (var i = 0; i < data.length; i++) {
         if (data[i] == 10 || data[i] == 13) { // Newline char was found.
           lineCount++;
-          if (line.length) emit(lineCount, byteCount);
+          if (lineLength) emit(lineCount, byteCount);
         } else {
-          line.push(data[i]); // Buffer new line data.
+          lineBuffer[lineLength] = data[i]; // Buffer new line data.
+          lineLength++;
         }
         byteCount++;
      }
@@ -40,7 +43,7 @@ var readLine = module.exports = function(file, opts) {
   })
   .on('end', function() {
     // Emit last line if anything left over since EOF won't trigger it.
-    if (line.length) {
+    if (lineLength) {
       lineCount++;
       emit(lineCount, byteCount);
     }

--- a/readline.js
+++ b/readline.js
@@ -12,7 +12,13 @@ var readLine = module.exports = function(file, opts) {
       lineCount = 0,
       byteCount = 0,
       emit = function(lineCount, byteCount) {
-        self.emit('line', new Buffer(line).toString(), lineCount, byteCount);
+        try {
+          self.emit('line', new Buffer(line).toString(), lineCount, byteCount);
+        } catch (err) {
+          self.emit('error', err);
+        } finally {
+          line = []; // Empty buffer.
+        }
       };
     this.input = ('string' === typeof file) ? fs.createReadStream(file, opts) : file;
     this.input.on('open', function(fd) {
@@ -23,7 +29,6 @@ var readLine = module.exports = function(file, opts) {
         if (data[i] == 10 || data[i] == 13) { // Newline char was found.
           lineCount++;
           if (line.length) emit(lineCount, byteCount);
-          line = []; // Empty buffer.
         } else {
           line.push(data[i]); // Buffer new line data.
         }

--- a/readline.js
+++ b/readline.js
@@ -11,7 +11,7 @@ var readLine = module.exports = function(file, opts) {
       line = [],
       lineCount = 0,
       byteCount = 0,
-      emit = function(line, lineCount, byteCount) {
+      emit = function(lineCount, byteCount) {
         self.emit('line', new Buffer(line).toString(), lineCount, byteCount);
       };
     this.input = ('string' === typeof file)? fs.createReadStream(file, opts):file;
@@ -22,7 +22,7 @@ var readLine = module.exports = function(file, opts) {
      for (var i = 0; i < data.length; i++) {
         if (data[i] == 10 || data[i] == 13) { // Newline char was found.
           lineCount++;
-          if (line.length) emit(line, lineCount, byteCount);
+          if (line.length) emit(lineCount, byteCount);
           line = []; // Empty buffer.
         } else {
           line.push(data[i]); // Buffer new line data.
@@ -37,7 +37,7 @@ var readLine = module.exports = function(file, opts) {
     // Emit last line if anything left over since EOF won't trigger it.
     if (line.length) {
       lineCount++;
-      emit(line, lineCount, byteCount);
+      emit(lineCount, byteCount);
     }
     self.emit('end');
   })

--- a/test/test_readline.js
+++ b/test/test_readline.js
@@ -98,16 +98,18 @@ test("processing error passed on", function(t){
 
   rl.on("line", function (line, ln, byteCount){
     lineCalls++;
-    throw new Error('fake error');
+    if (ln === 7) {
+      throw new Error('fake error');
+    }
   });
   rl.on("error", function (err){
     if (!lastError) {
       lastError = err;
-      t.ok(err.message === 'fake error','error is passed on');
     }
   });
 
   rl.on("end", function (){
+    t.ok(lastError.message === 'fake error','error is passed on');
     t.ok(lineCalls === 7, 'line count ok');
     t.end();
   });

--- a/test/test_readline.js
+++ b/test/test_readline.js
@@ -90,3 +90,25 @@ test("byte count", function(t){
     t.end();
   });
 });
+
+test("processing error passed on", function(t){
+  var rl = readLine('./fixtures/nmbr.txt');
+  var lastError;
+  var lineCalls = 0;
+
+  rl.on("line", function (line, ln, byteCount){
+    lineCalls++;
+    throw new Error('fake error');
+  });
+  rl.on("error", function (err){
+    if (!lastError) {
+      lastError = err;
+      t.ok(err.message === 'fake error','error is passed on');
+    }
+  });
+
+  rl.on("end", function (){
+    t.ok(lineCalls === 7, 'line count ok');
+    t.end();
+  });
+});


### PR DESCRIPTION
I found that when the event handler for `line` generated an exception, even though I caught it, the line buffer was not reset and the last line was emitted twice.