### PR TITLE
Pass options as argument when using the new operator

### DIFF
--- a/readline.js
+++ b/readline.js
@@ -3,7 +3,7 @@ var fs = require('fs'),
     util = require('util');
 
 var readLine = module.exports = function(file, opts) {
-  if (!(this instanceof readLine)) return new readLine(file);
+  if (!(this instanceof readLine)) return new readLine(file, opts);
 
   EventEmitter.call(this);
   opts = opts || {};


### PR DESCRIPTION
When returning a new instance the options object was not being passed along the file argument.

This was not allowing the user to specify a max line length.